### PR TITLE
adapt for HDFS 3.3.x and xrootd 5.5.x

### DIFF
--- a/rpm/xrootd-hdfs.spec
+++ b/rpm/xrootd-hdfs.spec
@@ -18,11 +18,12 @@ BuildRequires: xrootd-devel >= 1:%{xrootd_current_major}
 BuildRequires: xrootd-devel <  1:%{xrootd_next_major}
 BuildRequires: cmake
 BuildRequires: /usr/include/hdfs.h
-BuildRequires: java-devel = 1:1.7.0
+BuildRequires: java-devel = 1:1.8.0
 BuildRequires: jpackage-utils
 BuildRequires: openssl-devel
 BuildRequires: zlib-devel
-Requires: hadoop-client >= 2.0.0+545-1.cdh4.1.1
+Requires: hadoop-libhdfs >= 3.3.4
+Requires: hadoop-libhdfs < 3.4.0
 Requires: xrootd-server >= 1:%{xrootd_current_major}.%{xrootd_current_minor}
 Requires: xrootd-server <  1:%{xrootd_next_major}.0.0-1
 

--- a/rpm/xrootd-hdfs.spec
+++ b/rpm/xrootd-hdfs.spec
@@ -9,7 +9,7 @@ URL: https://github.com/UW-Madison-HEP/xrootd-hdfs
 Source0: %{name}-%{version}.tar.gz
 
 %define xrootd_current_major 5
-%define xrootd_current_minor 4
+%define xrootd_current_minor 5
 %define xrootd_next_major 6
 
 BuildRequires: xrootd-server-devel >= 1:%{xrootd_current_major}

--- a/rpm/xrootd-hdfs.spec
+++ b/rpm/xrootd-hdfs.spec
@@ -1,5 +1,5 @@
 Name: xrootd-hdfs
-Version: 2.2.1
+Version: 2.2.2
 Release: 1%{?dist}
 Summary: HDFS plugin for xrootd
 

--- a/rpm/xrootd-hdfs.sysconfig
+++ b/rpm/xrootd-hdfs.sysconfig
@@ -32,15 +32,6 @@ fi
 # SOFTWARE-2387
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${HADOOP_LIB_DIR}/lib/native
 
-# Pulls all jars from hadoop client package and conf files from HADOOP_CONF_DIR
-for jar in ${HADOOP_HOME}/client/*.jar; do
-  CLASSPATH+="$jar:"
-done
-CLASSPATH+="${HADOOP_CONF_DIR:-${HADOOP_HOME}/etc/hadoop}"
-
-
-#OSG change: needed to pick up xml defaults
-CLASSPATH="/etc/hadoop/conf:$CLASSPATH"
-
+CLASSPATH=$(hadoop classpath 2>/dev/null)
 export CLASSPATH=$CLASSPATH
 


### PR DESCRIPTION
What order will we upgrade the production cluster?
We did test the combo of xrootd-hdfs 2.2.0-1.1, xrootd 5.5.0, and HDFS 3.2 on the test cluster.  That worked, so if xrootd 5.5 installed on the prod cluster before HDFS 3.3, that should be safe.